### PR TITLE
Upgrade to Bugsnag 4

### DIFF
--- a/addon/utils/bugsnag-configuration.js
+++ b/addon/utils/bugsnag-configuration.js
@@ -8,11 +8,9 @@ export default class BugsnagConfiguration {
     this.valid = this._validate();
   }
 
-  apply(bugsnagInstance) {
+  setup(BugsnagClient) {
     if (this.valid) {
-      Object.keys(this.config).forEach((key) => {
-        bugsnagInstance[key] = this.config[key];
-      });
+      window.bugsnagClient = BugsnagClient(this.config);
     } else {
       /* eslint-disable no-console */
       console.error('[ember-cli-bugsnag] Could not start Bugsnag reporting because of configuration issues');

--- a/app/initializers/ember-cli-bugsnag.js
+++ b/app/initializers/ember-cli-bugsnag.js
@@ -1,5 +1,5 @@
 import config from '../config/environment';
-import Bugsnag from 'bugsnag';
+import BugsnagClient from 'bugsnag';
 
 import BugsnagConfiguration from 'ember-cli-bugsnag/utils/bugsnag-configuration';
 
@@ -14,7 +14,7 @@ export default {
     configVariables.appVersion = config.currentRevision || config.APP.version;
 
     if (typeof FastBoot === 'undefined') {
-      new BugsnagConfiguration(configVariables, releaseStage).apply(Bugsnag);
+      new BugsnagConfiguration(configVariables, releaseStage).setup(BugsnagClient);
     }
   }
 };

--- a/app/instance-initializers/bugsnag.js
+++ b/app/instance-initializers/bugsnag.js
@@ -48,8 +48,6 @@ export default {
   },
 
   _onError(error) {
-    this._setContext();
-    this._setUser();
     this._setNotifyException(error);
 
     /* eslint-disable no-console */
@@ -57,22 +55,28 @@ export default {
     /* eslint-enable no-console */
   },
 
-  _setContext() {
-    const router = get(this, 'router');
-    window.bugsnagClient.context = getContext(router);
-  },
-
   _setNotifyException(error) {
     const owner = get(this, 'owner');
     const metaData = appMethods.getMetaData ? appMethods.getMetaData(error, owner) : {};
-    window.bugsnagClient.notify(error);
+    const user = this._getUser();
+    const context = this._getContext();
+    window.bugsnagClient.notify(error, {
+      metaData,
+      user,
+      context,
+    });
   },
 
-  _setUser() {
+  _getContext() {
+    const router = get(this, 'router');
+    return getContext(router);
+  },
+
+  _getUser() {
     const owner = get(this, 'owner');
     if (appMethods.getUser) {
       const user = appMethods.getUser(owner);
-      window.bugsnagClient.user = user;
+      return user;
     }
   }
 };

--- a/app/instance-initializers/bugsnag.js
+++ b/app/instance-initializers/bugsnag.js
@@ -2,7 +2,6 @@ import Ember  from 'ember';
 import config from '../config/environment';
 import { getContext } from 'ember-cli-bugsnag/utils/errors';
 import * as appMethods from '../utils/bugsnag';
-import Bugsnag from 'bugsnag';
 
 const {
   get,
@@ -10,14 +9,15 @@ const {
 } = Ember;
 
 export function initialize(instance) {
-  if (Bugsnag.apiKey === undefined) {
+  if (window.bugsnagClient.config.apiKey === undefined) {
     return;
   }
   const currentEnv = config.environment;
   const bugsnagConfig = config.bugsnag || {};
   const releaseStage = bugsnagConfig.releaseStage || currentEnv;
+  const releaseStages = window.bugsnagClient.config.notifyReleaseStages;
 
-  if (currentEnv !== 'test' && Bugsnag.notifyReleaseStages.indexOf(releaseStage) !== -1) {
+  if (currentEnv !== 'test' && releaseStages.indexOf(releaseStage) !== -1) {
     const owner = instance.lookup ? instance : instance.container;
     const router = owner.lookup('router:main');
 
@@ -42,7 +42,7 @@ export default {
     const originalDidTransition = router.didTransition || function() {};
 
     return function() {
-      Bugsnag.refresh();
+      window.bugsnagClient.refresh();
       return originalDidTransition.apply(this, arguments);
     };
   },
@@ -59,20 +59,20 @@ export default {
 
   _setContext() {
     const router = get(this, 'router');
-    Bugsnag.context = getContext(router);
+    window.bugsnagClient.context = getContext(router);
   },
 
   _setNotifyException(error) {
     const owner = get(this, 'owner');
     const metaData = appMethods.getMetaData ? appMethods.getMetaData(error, owner) : {};
-    Bugsnag.notifyException(error, null, metaData);
+    window.bugsnagClient.notify(error);
   },
 
   _setUser() {
     const owner = get(this, 'owner');
     if (appMethods.getUser) {
       const user = appMethods.getUser(owner);
-      Bugsnag.user = user;
+      window.bugsnagClient.user = user;
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
     nodeAssets: {
       'bugsnag-js': {
         vendor: {
-          srcDir: 'src',
+          srcDir: 'dist',
           destDir: 'bugsnag-js',
           include: ['bugsnag.js'],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "node node-tests/**/*-test.js && ember try:testall"
   },
   "dependencies": {
-    "bugsnag-js": "^3.2.0",
+    "bugsnag-js": "^4.7.3",
     "ember-cli-babel": "^6.4.1",
     "ember-cli-node-assets": "^0.2.2",
     "fastboot-transform": "^0.1.1"

--- a/tests/acceptance/custom-release-stage-test.js
+++ b/tests/acceptance/custom-release-stage-test.js
@@ -2,7 +2,6 @@ import { test, module } from 'qunit';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 import config from 'dummy/config/environment';
-import Bugsnag from 'bugsnag';
 
 module('Acceptance | custom release stage config', {
   beforeEach() {
@@ -20,6 +19,6 @@ test('setting bugsnag releaseStage override environment', function(assert) {
   visit('/');
 
   andThen(function() {
-    assert.equal(Bugsnag.releaseStage, 'production');
+    assert.equal(window.bugsnagClient.config.releaseStage, 'production');
   });
 });

--- a/tests/acceptance/custom-user-test.js
+++ b/tests/acceptance/custom-user-test.js
@@ -2,7 +2,6 @@ import { test, module } from 'qunit';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 import config from 'dummy/config/environment';
-import Bugsnag from 'bugsnag';
 
 module('Acceptance | custom user', {
   beforeEach() {
@@ -20,19 +19,20 @@ module('Acceptance | custom user', {
 });
 
 test('with custom user set', function(assert) {
+  const expected = {
+    id: 123,
+    name: 'Dummy User',
+    email: 'dummy@example.com'
+  };
+
+  window.bugsnagClient.notify = function(error, options) {
+    assert.deepEqual(
+      options.user,
+      expected,
+      'user should equal what\'s returned from bugsnag util getUser()'
+    );
+  }
+
   visit('/');
   click('button');
-
-  andThen(function() {
-    const expected = {
-      id: 123,
-      name: 'Dummy User',
-      email: 'dummy@example.com'
-    };
-    assert.deepEqual(
-      Bugsnag.user,
-      expected,
-      'Bugsnag.user should equal what\'s returned from bugsnag util getUser()'
-    );
-  });
 });

--- a/tests/acceptance/environment-config-test.js
+++ b/tests/acceptance/environment-config-test.js
@@ -1,7 +1,6 @@
 import { test, module } from 'qunit';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-import Bugsnag from 'bugsnag';
 
 module('Acceptance | environment config', {
   beforeEach() {
@@ -17,6 +16,6 @@ test('visiting /environment-config', function(assert) {
   visit('/');
 
   andThen(function() {
-    assert.equal(Bugsnag.releaseStage, 'test');
+    assert.equal(window.bugsnagClient.config.releaseStage, 'test');
   });
 });

--- a/tests/unit/utils/bugsnag-configuration-test.js
+++ b/tests/unit/utils/bugsnag-configuration-test.js
@@ -9,11 +9,14 @@ test('passes initialized values to bugsnag instance', function(assert) {
     notifyReleaseStages: ['test']
   }, 'insomnia');
 
-  let bugsnagInstance = {};
-  configuration.apply(bugsnagInstance);
-  assert.equal(bugsnagInstance['apiKey'], 'UALSCA319');
-  assert.equal(bugsnagInstance['releaseStage'], 'insomnia');
-  assert.deepEqual(bugsnagInstance['notifyReleaseStages'], ['test']);
+  let bugsnagConfig = {};
+  const bugsnagObject = function(_config) {
+    bugsnagConfig = _config
+  };
+  configuration.setup(bugsnagObject);
+  assert.equal(bugsnagConfig['apiKey'], 'UALSCA319');
+  assert.equal(bugsnagConfig['releaseStage'], 'insomnia');
+  assert.deepEqual(bugsnagConfig['notifyReleaseStages'], ['test']);
 });
 
 test('sets default a default for notifyReleaseStages', function(assert) {
@@ -21,15 +24,21 @@ test('sets default a default for notifyReleaseStages', function(assert) {
     apiKey: 'UALSCA319'
   }, 'insomnia');
 
-  let bugsnagInstance = {};
-  configuration.apply(bugsnagInstance);
-  assert.deepEqual(bugsnagInstance['notifyReleaseStages'], ['production']);
+  let bugsnagConfig = {};
+  const bugsnagObject = function(_config) {
+    bugsnagConfig = _config;
+  };
+  configuration.setup(bugsnagObject);
+  assert.deepEqual(bugsnagConfig['notifyReleaseStages'], ['production']);
 });
 
 test('does not set any values if there is a configuration problem', function(assert) {
   let configuration = new BugsnagConfiguration({});
 
-  let bugsnagInstance = {};
-  configuration.apply(bugsnagInstance);
-  assert.deepEqual(bugsnagInstance, {});
+  let bugsnagConfig = {};
+  const bugsnagObject = function(_config) {
+    bugsnagConfig = _config;
+  };
+  configuration.setup(bugsnagObject);
+  assert.deepEqual(bugsnagConfig, {});
 });

--- a/vendor/bugsnag/shim.js
+++ b/vendor/bugsnag/shim.js
@@ -5,7 +5,7 @@ define('bugsnag', [], function() {
 
   if (typeof FastBoot === 'undefined') {
     return {
-      default: bugsnag
+      default: window.bugsnag
     };
   }
 

--- a/vendor/bugsnag/shim.js
+++ b/vendor/bugsnag/shim.js
@@ -1,11 +1,11 @@
-/* globals Bugsnag */
+/* globals bugsnag */
 
 define('bugsnag', [], function() {
   'use strict';
 
   if (typeof FastBoot === 'undefined') {
     return {
-      default: Bugsnag
+      default: bugsnag
     };
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,6 +193,16 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@bugsnag/cuid@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/cuid/-/cuid-3.0.0.tgz#2ee7642a30aee6dc86f5e7f824653741e42e5c35"
+  integrity sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg==
+
+"@bugsnag/safe-json-stringify@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@bugsnag/safe-json-stringify/-/safe-json-stringify-2.1.0.tgz#c7dd30a33bd888c39cd36d45216f7252f307ed36"
+  integrity sha512-tE2cPhAq+WFnA9XrfMfP+u/6L63eH7+PmONMNSXtP6kPt/iUXnwkDsxc1Q6lUP1oM3LsmWBrxn+/93M8JE6fpA==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -2172,6 +2182,14 @@ broccoli@^3.2.0:
     underscore.string "^3.2.2"
     watch-detector "^1.0.0"
 
+browserify-versionify@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/browserify-versionify/-/browserify-versionify-1.0.6.tgz#ab2dc61d6a119e627bec487598d1983b7fdb275e"
+  integrity sha1-qy3GHWoRnmJ77Eh1mNGYO3/bJ14=
+  dependencies:
+    find-root "^0.1.1"
+    through2 "0.6.3"
+
 browserslist@^3.2.6:
   version "3.2.8"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
@@ -2215,10 +2233,17 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-bugsnag-js@^3.2.0:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/bugsnag-js/-/bugsnag-js-3.3.3.tgz#df35ec523a00d4be72e782a616bfa3f7da178f8b"
-  integrity sha512-0czzmbOXpWs2I+IbBkHz78py78nZTwGE8IoSpM8XU30JNsUwsvE59qJZ0kO6S8NkTzuVMt3IVGCG2txk4BdhaQ==
+bugsnag-js@^4.7.3:
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/bugsnag-js/-/bugsnag-js-4.7.3.tgz#fd81eed6882b629d5f059de5bc916ecd19c82aa1"
+  integrity sha512-j9n6E45y8R0hx4A2IGkbOIEsDwRzZlhe+rtCfFo6RE6DgmTezeia+kqUMb4iitkSCZjEBMAPGhAe1l3vXfwbqQ==
+  dependencies:
+    "@bugsnag/cuid" "^3.0.0"
+    "@bugsnag/safe-json-stringify" "^2.1.0"
+    browserify-versionify "^1.0.6"
+    error-stack-parser "^2.0.2"
+    iserror "0.0.2"
+    stack-generator "^2.0.3"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -3785,6 +3810,13 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-stack-parser@^2.0.2:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.6.tgz#5a99a707bd7a4c58a797902d48d82803ede6aad8"
+  integrity sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==
+  dependencies:
+    stackframe "^1.1.1"
+
 error@^7.0.0:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/error/-/error-7.2.1.tgz#eab21a4689b5f684fc83da84a0e390de82d94894"
@@ -4334,6 +4366,11 @@ find-index@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/find-index/-/find-index-1.1.1.tgz#4b221f8d46b7f8bea33d8faed953f3ca7a081cbc"
   integrity sha512-XYKutXMrIK99YMUPf91KX5QVJoG31/OsgftD6YoTPAObfQIxM4ziA9f0J1AsqKhJmo+IeaIPP0CFopTD4bdUBw==
+
+find-root@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-0.1.2.tgz#98d2267cff1916ccaf2743b3a0eea81d79d7dcd1"
+  integrity sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE=
 
 find-up@4.1.0, find-up@^4.1.0:
   version "4.1.0"
@@ -5874,6 +5911,11 @@ isbinaryfile@^3.0.3:
   integrity sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==
   dependencies:
     buffer-alloc "^1.2.0"
+
+iserror@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/iserror/-/iserror-0.0.2.tgz#bd53451fe2f668b9f2402c1966787aaa2c7c0bf5"
+  integrity sha1-vVNFH+L2aLnyQCwZZnh6qix8C/U=
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -8212,7 +8254,7 @@ read@1, read@~1.0.1, read@~1.0.7:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@~1.0.2:
+"readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0.2:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
@@ -9269,6 +9311,18 @@ ssri@^6.0.0, ssri@^6.0.1:
   dependencies:
     figgy-pudding "^3.5.1"
 
+stack-generator@^2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.5.tgz#fb00e5b4ee97de603e0773ea78ce944d81596c36"
+  integrity sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==
+  dependencies:
+    stackframe "^1.1.1"
+
+stackframe@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
+  integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -9570,6 +9624,14 @@ thenify-all@^1.0.0:
   integrity sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
   dependencies:
     any-promise "^1.0.0"
+
+through2@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.3.tgz#795292fde9f254c2a368b38f9cc5d1bd4663afb6"
+  integrity sha1-eVKS/enyVMKjaLOPnMXRvUZjr7Y=
+  dependencies:
+    readable-stream ">=1.0.33-1 <1.1.0-0"
+    xtend ">=4.0.0 <4.1.0-0"
 
 through2@^2.0.0:
   version "2.0.5"
@@ -10305,7 +10367,7 @@ xmlhttprequest-ssl@~1.5.4:
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
   integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
 
-xtend@^4.0.0, xtend@~4.0.1:
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
Upgrade ember-cli-bugsnag to use the latest 4.x version of the [bugsnag-js](https://github.com/bugsnag/bugsnag-js) client.

I followed their migration guide at https://github.com/bugsnag/bugsnag-js/blob/master/UPGRADING.md. There are two _important_ changes here, ember-cli-bugsnag now instantiates bugsnag, rather than configuring it, and we're using the new notify API to send along the metadata/user, rather than setting those before sending the error across.

As it's quite outdated, we also should upgrade the ember-source version and some of our other dependencies, but these can be done separately to keep the scope of the PR down.

Tests are green, but we should probably do some sanity QA!

Fixes #81, thanks to @alonski for laying some groundwork in https://github.com/binhums/ember-cli-bugsnag/pull/82 and https://github.com/binhums/ember-cli-bugsnag/pull/80!
