### PR TITLE
Using currentRoute to retrieve route name

### DIFF
--- a/addon/utils/errors.js
+++ b/addon/utils/errors.js
@@ -2,7 +2,12 @@ import Ember from 'ember';
 
 export function getContext(router) {
   var url = router.get('location').getURL();
-  var routeName = router.currentRoute.name;
+  var routeName;
+  if(Ember.VERSION >= '2.15') {
+    routeName = router.currentRouteName;
+  } else {
+    routeName = infos[infos.length - 1].name;
+  }
 
   var firstSegments = routeName.replace(".index", "").replace(/\./g, ' ');
   var prettyRouteName = Ember.String.capitalize(firstSegments);

--- a/addon/utils/errors.js
+++ b/addon/utils/errors.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export function getContext(router) {
   var url = router.get('location').getURL();
-  var routeName = currentRoute.name;
+  var routeName = router.currentRoute.name;
 
   var firstSegments = routeName.replace(".index", "").replace(/\./g, ' ');
   var prettyRouteName = Ember.String.capitalize(firstSegments);

--- a/addon/utils/errors.js
+++ b/addon/utils/errors.js
@@ -1,10 +1,8 @@
 import Ember from 'ember';
 
 export function getContext(router) {
-  var infos = router.currentState.routerJsState.handlerInfos;
-
   var url = router.get('location').getURL();
-  var routeName = infos[infos.length - 1].name;
+  var routeName = currentRoute.name;
 
   var firstSegments = routeName.replace(".index", "").replace(/\./g, ' ');
   var prettyRouteName = Ember.String.capitalize(firstSegments);


### PR DESCRIPTION
I encountered a bug when with handlerInfos not existing after upgrading to ember 3.13

I fixed the issue by using the currentRoute instead.

https://deprecations.emberjs.com/v3.x/#toc_remove-handler-infos